### PR TITLE
fix issue #49

### DIFF
--- a/android/src/main/java/com/xamdesign/safe_device/Emulator/EmulatorCheck.java
+++ b/android/src/main/java/com/xamdesign/safe_device/Emulator/EmulatorCheck.java
@@ -70,7 +70,7 @@ public class EmulatorCheck {
                 || "QC_Reference_Phone" == Build.BOARD && !"xiaomi".equalsIgnoreCase(Build.MANUFACTURER)
                 //bluestacks
                 || Build.MANUFACTURER.contains("Genymotion")
-                || Build.HOST.startsWith("Build")
+                || (Build.HOST.startsWith("Build") && !Build.MANUFACTURER.equalsIgnoreCase("sony"))
                 //MSI App Player
                 || Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")
                 || Build.PRODUCT == "google_sdk"


### PR DESCRIPTION
This fix still detects bluestacks as emulator, but doesn't give false-positive result for Sony devices. 
Tested against Sony XQ-DC54 and BlueStacks 5.