### PR TITLE
Implemented SafeDeviceConfig to enable or disable automated checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.3.5
+
+* **Android Configurable Mock Location Detection**: The mock location check on Android is now conditional based on the configuration provided via the `init` method from Dart. If `mockLocationCheckEnabled` is set to `false`, mock location detection is disabled and location updates are not started. If no configuration is provided, the plugin behaves exactly as before for full backward compatibility.
+* **iOS Config Support**: The iOS plugin now accepts and stores the configuration from Dart via the `init` method, mirroring the Android API. While iOS does not currently use the mock location flag, this enables future extensibility and API consistency.
+
+### Technical Details
+- Added `SafeDeviceConfig` class, served to both Platform to include `mockLocationCheckEnabled` and future possible configuration
+- Added `init` method to both Android and iOS native plugins to receive and store configuration from Dart.
+- Android: Location updates and mock location checks are only started if enabled in config.
+- iOS: Configuration is stored for future use, since the only configuration available now is for mock location check which is not supported on iOS.
+
 ## 1.3.4 
 
 - **CRITICAL**: Fixed false positive root detection on real Android devices (especially Xiaomi/Redmi devices)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In your flutter project add the dependency:
 ```yml
 dependencies:
 ...
-  safe_device: ^1.3.4
+  safe_device: ^1.3.5
 ```
 
 ## Usage
@@ -22,6 +22,23 @@ dependencies:
 import 'package:safe_device/safe_device.dart';
 ```
 
+#### Configuration
+
+You can configure the plugin at startup using `SafeDevice.init` and `SafeDeviceConfig`. This is useful if you want to disable automatic check such as the mock location detection.
+
+```dart
+import 'package:safe_device/safe_device.dart';
+import 'package:safe_device/safe_device_config.dart';
+
+void main() async {
+  SafeDevice.init(
+    SafeDeviceConfig(mockLocationCheckEnabled: false), // disables mock location check on Android
+  );
+  // ...rest of your app
+}
+```
+
+It's not mandatory to configure the plugin at the start, if not provided a default configuration with everything enable is provided automatically
 #### Using it
 
 Checks whether device JailBroken on iOS/Android?
@@ -48,11 +65,15 @@ Checks whether device is real or emulator
 bool isRealDevice = await SafeDevice.isRealDevice;
 ```
 
-Can this device mock location - no need to root!
+bool isMockLocation = await SafeDevice.isMockLocation;
 
 ```
 bool isMockLocation = await SafeDevice.isMockLocation;
 ```
+
+**Android:** If mock location check is disabled via config, the check always returns `false` and no location updates are started. If enabled (default), the check is active.
+
+**iOS:** The config is stored for future use but does not affect current detection logic. Mock location detection on iOS is based on jailbreak/emulator status.
 
 (ANDROID ONLY) Check if application is running on external storage
 
@@ -119,15 +140,12 @@ Map<String, bool> details = await SafeDevice.jailbreakDetails;
 // }
 ```
 
+
 # Note:
 
 #### Mock location detection
 
-* **Android** - Location permission needs to be granted in app in order to detect mock location
-  properly
-* **iOS** - For now we are checking if device is Jail Broken or if it's not real device. There is no
-  strong detection of mock location in iOS *(Open the PR if you have better way for mock location
-  detection in iOS)*
+* **Android** - Location permission is required to detect mock location. The check can be disabled at runtime via config.
 
 ### DevelopmentMode
 

--- a/android/src/main/java/com/xamdesign/safe_device/SafeDeviceConfig.java
+++ b/android/src/main/java/com/xamdesign/safe_device/SafeDeviceConfig.java
@@ -1,0 +1,15 @@
+class SafeDeviceConfig {
+    private boolean mockLocationCheckEnabled;
+
+    public SafeDeviceConfig(boolean mockLocationCheckEnabled) {
+        this.mockLocationCheckEnabled = mockLocationCheckEnabled;
+    }
+
+    public SafeDeviceConfig(Map<String, Object> map) {
+        this.mockLocationCheckEnabled = (boolean) map.get("mockLocationCheckEnabled");
+    }   
+    public boolean isMockLocationCheckEnabled() {
+        return mockLocationCheckEnabled;
+    }
+
+}

--- a/android/src/main/java/com/xamdesign/safe_device/SafeDeviceConfig.java
+++ b/android/src/main/java/com/xamdesign/safe_device/SafeDeviceConfig.java
@@ -1,4 +1,9 @@
-class SafeDeviceConfig {
+package com.xamdesign.safe_device;
+
+
+import java.util.Map;
+
+public class SafeDeviceConfig {
     private boolean mockLocationCheckEnabled;
 
     public SafeDeviceConfig(boolean mockLocationCheckEnabled) {

--- a/android/src/main/java/com/xamdesign/safe_device/SafeDevicePlugin.java
+++ b/android/src/main/java/com/xamdesign/safe_device/SafeDevicePlugin.java
@@ -25,10 +25,10 @@ public class SafeDevicePlugin implements FlutterPlugin, MethodChannel.MethodCall
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
         this.context = binding.getApplicationContext();
-        locationAssistantListener = new LocationAssistantListener(context);
+        // locationAssistantListener = new LocationAssistantListener(context);
 
-        // Start location updates if needed
-        locationAssistantListener.getAssistant().startLocationUpdates();
+        // // Start location updates if needed
+        // locationAssistantListener.getAssistant().startLocationUpdates();
 
         final MethodChannel channel = new MethodChannel(
                 binding.getBinaryMessenger(),
@@ -83,8 +83,29 @@ public class SafeDevicePlugin implements FlutterPlugin, MethodChannel.MethodCall
             }
         } else if (call.method.equals("rootDetectionDetails")) {
             result.success(RootedCheck.getRootDetectionDetails(context));
+        } else if (call.method.equals("init")) {
+            var configMap = call.arguments as Map<String, Object>;
+            SafeDeviceConfig config = new SafeDeviceConfig(configMap);
+            SafeDevicePlugin.init(context, config);
+            result.success(null);
         } else {
             result.notImplemented();
+        }
+    }
+
+    public static void init(Context context, SafeDeviceConfig config) {
+        // Start location updates if mock location check is enabled
+        if (config.isMockLocationCheckEnabled()) {
+            if (locationAssistantListener == null) {
+                locationAssistantListener = new LocationAssistantListener(context);
+            }
+            // Ensure the assistant is initialized
+            locationAssistantListener.getAssistant().startLocationUpdates();
+        } else {
+            if (locationAssistantListener != null) {                
+                // Stop location updates if mock location check is disabled
+                locationAssistantListener.getAssistant().stopLocationUpdates();
+            }
         }
     }
 

--- a/android/src/main/java/com/xamdesign/safe_device/SafeDevicePlugin.java
+++ b/android/src/main/java/com/xamdesign/safe_device/SafeDevicePlugin.java
@@ -10,10 +10,13 @@ import com.xamdesign.safe_device.Emulator.EmulatorCheck;
 import com.xamdesign.safe_device.ExternalStorage.ExternalStorageCheck;
 import com.xamdesign.safe_device.MockLocation.LocationAssistant;
 import com.xamdesign.safe_device.Rooted.RootedCheck;
+import com.xamdesign.safe_device.SafeDeviceConfig;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+
+import java.util.Map;
 
 /**
  * SafeDevicePlugin
@@ -84,7 +87,8 @@ public class SafeDevicePlugin implements FlutterPlugin, MethodChannel.MethodCall
         } else if (call.method.equals("rootDetectionDetails")) {
             result.success(RootedCheck.getRootDetectionDetails(context));
         } else if (call.method.equals("init")) {
-            var configMap = call.arguments as Map<String, Object>;
+            @SuppressWarnings("unchecked")
+            Map<String, Object> configMap = (Map<String, Object>) call.arguments;
             SafeDeviceConfig config = new SafeDeviceConfig(configMap);
             SafeDevicePlugin.init(context, config);
             result.success(null);
@@ -96,6 +100,7 @@ public class SafeDevicePlugin implements FlutterPlugin, MethodChannel.MethodCall
     public static void init(Context context, SafeDeviceConfig config) {
         // Start location updates if mock location check is enabled
         if (config.isMockLocationCheckEnabled()) {
+
             if (locationAssistantListener == null) {
                 locationAssistantListener = new LocationAssistantListener(context);
             }

--- a/ios/Classes/SafeDeviceConfig.h
+++ b/ios/Classes/SafeDeviceConfig.h
@@ -1,0 +1,38 @@
+#import <Foundation/Foundation.h>
+
+@protocol SafeDeviceConfigProtocol <NSObject>
+@end
+
+@interface SafeDeviceConfig : NSObject <SafeDeviceConfigProtocol>
+
+@property (nonatomic, assign) BOOL mockLocationCheckEnabled;
+
+- (instancetype)initWithMockLocationCheckEnabled:(BOOL)mockLocationCheckEnabled;
+- (instancetype)initWithDictionary:(NSDictionary *)dict;
+
+@end
+
+@implementation SafeDeviceConfig
+
+- (instancetype)initWithMockLocationCheckEnabled:(BOOL)mockLocationCheckEnabled {
+    self = [super init];
+    if (self) {
+        _mockLocationCheckEnabled = mockLocationCheckEnabled;
+    }
+    return self;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary *)dict {
+    self = [super init];
+    if (self) {
+        NSNumber *mockLocation = dict[@"mockLocationCheckEnabled"];
+        if (mockLocation && [mockLocation isKindOfClass:[NSNumber class]]) {
+            _mockLocationCheckEnabled = [mockLocation boolValue];
+        } else {
+            _mockLocationCheckEnabled = NO;
+        }
+    }
+    return self;
+}
+
+@end

--- a/ios/Classes/SafeDevicePlugin.m
+++ b/ios/Classes/SafeDevicePlugin.m
@@ -1,6 +1,10 @@
 #import "SafeDevicePlugin.h"
 #import <DTTJailbreakDetection/DTTJailbreakDetection.h>
 
+@interface SafeDevicePlugin ()
+@property (nonatomic, strong) SafeDeviceConfig *config;
+@end
+
 @implementation SafeDevicePlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   FlutterMethodChannel* channel = [FlutterMethodChannel
@@ -25,7 +29,11 @@
     result([NSNumber numberWithBool:([self isJailBroken] || ![self isRealDevice])]);
   }else if ([@"isRealDevice" isEqualToString:call.method]) {
     result([NSNumber numberWithBool:[self isRealDevice]]);
-  } else {
+  }else if ([@"init" isEqualToString:call.method]) {
+        NSDictionary *dict = call.arguments;
+        self.config = [[SafeDeviceConfig alloc] initWithDictionary:dict];
+        result(nil);
+    } else {
     result(FlutterMethodNotImplemented);
   }
 }

--- a/lib/safe_device.dart
+++ b/lib/safe_device.dart
@@ -2,13 +2,37 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:safe_device/safe_device_config.dart';
 
 class SafeDevice {
   static const MethodChannel _channel = const MethodChannel('safe_device');
 
+  static SafeDeviceConfig? _safeDeviceConfig;
+  static bool isInitiated = false;
+
+  static void init(SafeDeviceConfig config) {
+    if (isInitiated) {
+      print('SafeDevice has already been initiated, skipping');
+      return;
+    }
+    _channel.invokeMethod('init', config.toMap());
+
+    _safeDeviceConfig = config;
+    isInitiated = true;
+  }
+
+  static void ensureInitiated() {
+    if (isInitiated) {
+      return;
+    }
+    const SafeDeviceConfig defaultConfig = const SafeDeviceConfig();
+    init(defaultConfig);
+  }
+
   // Checks whether device is JailBroken (iOS) or Rooted (Android)
   static Future<bool> get isJailBroken async {
     try {
+      ensureInitiated();
       final bool isJailBroken = await _channel.invokeMethod('isJailBroken');
       return isJailBroken;
     } catch (e) {
@@ -19,6 +43,7 @@ class SafeDevice {
 
   // (iOS ONLY) Checks whether device is JailBroken using custom detection
   static Future<bool> get isJailBrokenCustom async {
+    ensureInitiated();
     if (Platform.isIOS) {
       final bool jailbroken = await _channel.invokeMethod('isJailBrokenCustom');
       return jailbroken;
@@ -28,6 +53,7 @@ class SafeDevice {
 
   // (iOS ONLY) Get detailed breakdown of jailbreak detection methods
   static Future<Map<String, dynamic>> get jailbreakDetails async {
+    ensureInitiated();
     if (Platform.isIOS) {
       final Map<Object?, Object?> result =
           await _channel.invokeMethod('jailbreakDetails');
@@ -38,8 +64,12 @@ class SafeDevice {
 
   // Can this device mock location - no need to root!
   static Future<bool> get isMockLocation async {
+    ensureInitiated();
     try {
       if (Platform.isAndroid) {
+        if (_safeDeviceConfig?.mockLocationCheckEnabled == false) {
+          return false; // Skip mock location check if disabled in config
+        }
         final bool isMockLocation =
             await _channel.invokeMethod('isMockLocation');
         return isMockLocation;
@@ -54,6 +84,7 @@ class SafeDevice {
 
   // Checks whether the device is real or an emulator
   static Future<bool> get isRealDevice async {
+    ensureInitiated();
     try {
       final bool isRealDevice = await _channel.invokeMethod('isRealDevice');
       return isRealDevice;
@@ -65,6 +96,7 @@ class SafeDevice {
 
   // (ANDROID ONLY) Check if the application is running on external storage
   static Future<bool> get isOnExternalStorage async {
+    ensureInitiated();
     if (Platform.isIOS) return false;
     try {
       final bool isOnExternalStorage =
@@ -78,6 +110,7 @@ class SafeDevice {
 
   // Check if device violates any of the above conditions
   static Future<bool> get isSafeDevice async {
+    ensureInitiated();
     try {
       final bool jailBroken = await isJailBroken;
       final bool realDevice = await isRealDevice;
@@ -94,6 +127,7 @@ class SafeDevice {
 
   // (ANDROID ONLY) Check if Development Options is enabled on the device
   static Future<bool> get isDevelopmentModeEnable async {
+    ensureInitiated();
     if (Platform.isIOS) return false;
     try {
       final bool isDevModeEnabled =
@@ -107,6 +141,7 @@ class SafeDevice {
 
   // (ANDROID ONLY) Check if USB Debugging is enabled on the device
   static Future<bool> get isUsbDebuggingEnabled async {
+    ensureInitiated();
     if (Platform.isIOS) return false;
     try {
       final bool usbDebuggingEnabled =
@@ -122,6 +157,7 @@ class SafeDevice {
   /// This provides a breakdown of all detection methods for debugging
   /// Returns empty map on iOS devices
   static Future<Map<String, dynamic>> get rootDetectionDetails async {
+    ensureInitiated();
     if (Platform.isAndroid) {
       final Map<Object?, Object?> result =
           await _channel.invokeMethod('rootDetectionDetails');

--- a/lib/safe_device_config.dart
+++ b/lib/safe_device_config.dart
@@ -1,0 +1,11 @@
+class SafeDeviceConfig {
+  final bool mockLocationCheckEnabled;
+
+  const SafeDeviceConfig({this.mockLocationCheckEnabled = true});
+
+  Map<String, dynamic> toMap() {
+    return {
+      'mockLocationCheckEnabled': mockLocationCheckEnabled,
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: safe_device
 description: This package helps to detect iOS Simulator, Android Emulator and Debug Mode. This package also detects MockLocation/Fake GPS location on Android Device. Also check device is real or not.
-version: 1.3.4
+version: 1.3.5
 homepage: https://github.com/xamdesign/safe_device
 
 environment:


### PR DESCRIPTION
As of today, on Android, when the app for any reason has granted the location permission (even if not requested by safe_device in the first place, for example for a map inside your app) at the startup it will access the location to check if the device has a mocked location and start to listen for position updates, now is not possible to disable this check at the startup. The aim of this PR is to being able to configure this, and possibly, future other automated check by providing a configuration object. 

The change made is documented in the both the change log and the readme. It basically create and store a configuration when you provide one to the `init` method or a default one (which basically let the plugin works as today) is automatically provided whenever a check is requested by dart code like for example  `SafeDevice.isSafeDevice`