### PR TITLE
Jailbreak details method name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.3.9
 
 * Resolved (#86)[https://github.com/ufukhawk/safe_device/issues/86]. Fixed `SafeDeviceJailbreakDetection` not being called by `isJailBrokenCustom` nor `isJailBroken`.
+* Resolved (#77)[https://github.com/ufukhawk/safe_device/issues/77]. Fixed `jailbreakDetails` method channel name.
+* Added missing bool cast for `isSimulator` value in `jailbreakDetails`.
 
 ## 1.3.8
 * iOS bug fix

--- a/ios/Classes/SafeDevicePlugin.m
+++ b/ios/Classes/SafeDevicePlugin.m
@@ -26,8 +26,8 @@
     result([NSNumber numberWithBool:[self isJailBroken]]);
   }else if ([@"isJailBrokenCustom" isEqualToString:call.method]) {
     result([NSNumber numberWithBool:[self isJailBrokenCustom]]);
-  }else if ([@"getJailbreakDetails" isEqualToString:call.method]) {
-    result([self getJailbreakDetails]);
+  }else if ([@"jailbreakDetails" isEqualToString:call.method]) {
+    result([self jailbreakDetails]);
   }else if ([@"canMockLocation" isEqualToString:call.method]) {
     //For now we have returned if device is Jail Broken or if it's not real device. There is no
     //strong detection of Mock location in iOS
@@ -159,7 +159,7 @@
     return [SafeDeviceJailbreakDetection isJailbroken];
 }
 
-- (NSDictionary*)getJailbreakDetails {
+- (NSDictionary*)jailbreakDetails {
     BOOL isDev = [self isDevelopmentEnvironment];
     BOOL hasLegitEnvVars = [self hasLegitimateEnvironmentVariables];
     BOOL obviousJailbreak = [self hasObviousJailbreakSigns];

--- a/ios/Classes/SafeDevicePlugin.m
+++ b/ios/Classes/SafeDevicePlugin.m
@@ -170,7 +170,7 @@
         @"hasLegitimateEnvironmentVariables": @(hasLegitEnvVars),
         @"hasObviousJailbreakSigns": @(obviousJailbreak),
         @"dttResult": @([DTTJailbreakDetection isJailbroken]),
-        @"customResult": @([SafeDeviceJailbreakDetection isJailbroken])
+        @"customResult": @([SafeDeviceJailbreakDetection isJailbroken]),
         @"finalResult": @([self isJailBroken])
     };
 }

--- a/ios/Classes/SafeDevicePlugin.m
+++ b/ios/Classes/SafeDevicePlugin.m
@@ -165,7 +165,7 @@
     BOOL obviousJailbreak = [self hasObviousJailbreakSigns];
     
     return @{
-        @"isSimulator": @(TARGET_OS_SIMULATOR),
+        @"isSimulator": @((BOOL) TARGET_OS_SIMULATOR),
         @"isDevelopmentEnvironment": @(isDev),
         @"hasLegitimateEnvironmentVariables": @(hasLegitEnvVars),
         @"hasObviousJailbreakSigns": @(obviousJailbreak),


### PR DESCRIPTION
Resolves #77 (it wasn't actually resolved in the current version, maybe it was at some point).

Also adds a missing `,` in `@"customResult": @([SafeDeviceJailbreakDetection isJailbroken]),` and casts `isSimulator` to bool (TBH I don't understand why `jailbreakDetails` has been changed from `Map<String, bool> to Map<String, dynamic>`).

The example now works fully, before the Jailbreak Detection Details (iOS) section didn't load due to an exception on `jailbreakDetails = await SafeDevice.jailbreakDetails;`

![IMG_35552574FA7B-1](https://github.com/user-attachments/assets/50f12e27-0698-4440-b531-4147ba425120)
