### PR TITLE
Add most common rootless jailbreak paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.3.9
 
 * Resolved (#86)[https://github.com/ufukhawk/safe_device/issues/86]. Fixed `SafeDeviceJailbreakDetection` not being called by `isJailBrokenCustom` nor `isJailBroken`.
+* Added most common rootless jailbreak paths
 
 ## 1.3.8
 * iOS bug fix

--- a/ios/Classes/SafeDeviceJailbreakDetection.m
+++ b/ios/Classes/SafeDeviceJailbreakDetection.m
@@ -12,60 +12,73 @@
 
 #pragma mark - Jailbreak Detection Paths
 
+/// Paths under /var or /private/var check literally
+static NSArray<NSString *> * const jailbreakVarPaths = @[
+    @"/private/var/lib/apt",
+    @"/private/var/tmp/cydia.log",
+    @"/private/var/lib/dpkg",
+    @"/var/cache/apt",
+    @"/var/lib/cydia",
+    @"/var/log/syslog",
+    @"/var/lib/dpkg/status"
+];
+
+/// Paths checked literally and with /var/jb prefix
+static NSArray<NSString *> * const jailbreakNonVarPaths = @[
+    // Cydia and package managers
+    @"/Applications/Cydia.app",
+    @"/Applications/RockApp.app",
+    @"/Applications/Icy.app",
+    @"/Applications/WinterBoard.app",
+    @"/Applications/SBSettings.app",
+    @"/Applications/blackra1n.app",
+    @"/Applications/IntelliScreen.app",
+    @"/Applications/Snoop-itConfig.app",
+    
+    // System binaries commonly found on jailbroken devices
+    @"/bin/sh",
+    @"/bin/bash",
+    @"/usr/sbin/sshd",
+    @"/usr/libexec/sftp-server",
+    @"/usr/libexec/ssh-keysign",
+    
+    // MobileSubstrate and related files
+    @"/Library/MobileSubstrate/MobileSubstrate.dylib",
+    @"/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+    @"/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+    
+    // APT package manager
+    @"/etc/apt",
+    
+    // Launch daemons
+    @"/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
+    @"/System/Library/LaunchDaemons/com.ikey.bbot.plist",
+    
+    // Additional common jailbreak paths
+    @"/usr/sbin/frida-server",
+    @"/usr/bin/cycript",
+    @"/usr/local/bin/cycript",
+    @"/usr/lib/libcycript.dylib",
+    @"/etc/ssh/sshd_config",
+    @"/Applications/Terminal.app",
+    @"/Applications/iFile.app",
+    @"/Applications/Filza.app",
+    @"/usr/bin/dpkg",
+    @"/usr/sbin/dpkg"
+];
+
 /// Common jailbreak tool and application paths
 + (NSArray<NSString *> *)jailbreakPaths {
     static NSArray<NSString *> *paths = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        paths = @[
-            // Cydia and package managers
-            @"/private/var/lib/apt",
-            @"/Applications/Cydia.app",
-            @"/Applications/RockApp.app",
-            @"/Applications/Icy.app",
-            @"/Applications/WinterBoard.app",
-            @"/Applications/SBSettings.app",
-            @"/Applications/blackra1n.app",
-            @"/Applications/IntelliScreen.app",
-            @"/Applications/Snoop-itConfig.app",
-            
-            // System binaries commonly found on jailbroken devices
-            @"/bin/sh",
-            @"/bin/bash",
-            @"/usr/sbin/sshd",
-            @"/usr/libexec/sftp-server",
-            @"/usr/libexec/ssh-keysign",
-            
-            // MobileSubstrate and related files
-            @"/Library/MobileSubstrate/MobileSubstrate.dylib",
-            @"/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
-            @"/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
-            
-            // APT package manager
-            @"/etc/apt",
-            
-            // Launch daemons
-            @"/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
-            @"/System/Library/LaunchDaemons/com.ikey.bbot.plist",
-            
-            // Additional common jailbreak paths
-            @"/usr/sbin/frida-server",
-            @"/usr/bin/cycript",
-            @"/usr/local/bin/cycript",
-            @"/usr/lib/libcycript.dylib",
-            @"/var/cache/apt",
-            @"/var/lib/cydia",
-            @"/var/log/syslog",
-            @"/etc/ssh/sshd_config",
-            @"/private/var/tmp/cydia.log",
-            @"/Applications/Terminal.app",
-            @"/Applications/iFile.app",
-            @"/Applications/Filza.app",
-            @"/private/var/lib/dpkg",
-            @"/usr/bin/dpkg",
-            @"/usr/sbin/dpkg",
-            @"/var/lib/dpkg/status"
-        ];
+        NSMutableArray<NSString *> *expanded = [NSMutableArray array];
+        [expanded addObjectsFromArray:jailbreakVarPaths];
+        for (NSString *path in jailbreakNonVarPaths) {
+            [expanded addObject:path];
+            [expanded addObject:[@"/var/jb" stringByAppendingString:path]];
+        }
+        paths = [expanded copy];
     });
     return paths;
 }


### PR DESCRIPTION
Source: https://www.securitum.com/why_you_should_review_your_ios_defense_mechanisms.html

NOTE: I don't have a rooted device to actually test it. The list is initialized correctly but I cannot validate it further