### PR TITLE
Fix Android build by removing outdated `hasTestKeys` reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.10
+* Resolved [#96](https://github.com/ufukhawk/safe_device/issues/96). Fixed outdated `hasTestKeys` reference which caused Android builds to fail.
+
 ## 1.3.9
 
 * Resolved [#95](https://github.com/ufukhawk/safe_device/issues/95). Fixed `NullPointerException` crash when `isMockLocation` is called before the location listener is initialized (e.g. when `mockLocationCheckEnabled` is `false`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # safe_device (Null-Safety)
 
-<a href="https://pub.dev/packages/safe_device"><img src="https://img.shields.io/badge/pub-1.3.9-blue" alt="Safe Device" height="18"></a>
+<a href="https://pub.dev/packages/safe_device"><img src="https://img.shields.io/badge/pub-1.3.10-blue" alt="Safe Device" height="18"></a>
 <img src="https://imgur.com/Vw4Z93n.png" alt="Safe Device">
 Flutter (Null-Safety) Jailbroken, root, emulator and mock location detection.
 
@@ -11,7 +11,7 @@ In your flutter project add the dependency:
 ```yml
 dependencies:
 ...
-  safe_device: ^1.3.9
+  safe_device: ^1.3.10
 ```
 
 ## Usage

--- a/android/src/main/java/com/xamdesign/safe_device/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/xamdesign/safe_device/Rooted/RootedCheck.java
@@ -116,7 +116,6 @@ public class RootedCheck {
         details.put("hasObviousRootSigns", hasObviousRootSigns());
 
         // Build-specific checks
-        details.put("hasTestKeys", checkTestKeys());
         details.put("buildTagsHasTestKeys", checkBuildTags());
 
         // System properties

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: safe_device
 description: This package helps to detect iOS Simulator, Android Emulator and Debug Mode. This package also detects MockLocation/Fake GPS location on Android Device. Also check device is real or not.
-version: 1.3.9
+version: 1.3.10
 homepage: https://github.com/ufukhawk/safe_device
 
 environment:


### PR DESCRIPTION
Since updating to `1.3.9`, builds are failing on Android due to a reference to `checkTestKeys()` which was removed in the latest version (due to duplication).

This pull request removes the outdated reference.

Closes #96 