### PR TITLE
chore: migrate-to-built-in-kotlin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .dart_tool/
-
+.build/
 .packages
 .pub/
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2' // Uygun Android Gradle Plugin sürümü
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0" // Kotlin plugin ekleniyor
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 
@@ -18,7 +17,6 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace "com.xamdesign.safe_device"


### PR DESCRIPTION
- Added .build/ to .gitignore to exclude build artifacts.
- Removed the Kotlin Android plugin from android/build.gradle as it is no longer needed.