### PR TITLE
fix(ios): SPM resolution fails — DTTJailbreakDetection has no Package.swift

### DIFF
--- a/ios/safe_device/Package.swift
+++ b/ios/safe_device/Package.swift
@@ -25,7 +25,16 @@ let package = Package(
         .target(
             name: "DTTJailbreakDetection",
             path: "Sources/DTTJailbreakDetection",
-            publicHeadersPath: "include/DTTJailbreakDetection"
+            // publicHeadersPath defaults to "include". The header lives at
+            // include/DTTJailbreakDetection/DTTJailbreakDetection.h, so the public
+            // header's path is DTTJailbreakDetection/DTTJailbreakDetection.h, which is
+            // what `#import <DTTJailbreakDetection/DTTJailbreakDetection.h>` resolves to.
+            publicHeadersPath: "include",
+            // The .m file imports its header by bare name ("DTTJailbreakDetection.h"),
+            // so add the header's directory to the search path.
+            cSettings: [
+                .headerSearchPath("include/DTTJailbreakDetection")
+            ]
         ),
         .target(
             name: "safe_device",

--- a/ios/safe_device/Package.swift
+++ b/ios/safe_device/Package.swift
@@ -3,6 +3,12 @@
 
 import PackageDescription
 
+// DTTJailbreakDetection is vendored into Sources/DTTJailbreakDetection/ instead of
+// pulled from https://github.com/thii/DTTJailbreakDetection.git, because that upstream
+// repository ships no Package.swift (it is a CocoaPods-only pod). Referencing it as a
+// remote SwiftPM dependency made resolution fail with
+// "the package manifest at '/Package.swift' cannot be accessed". The vendored copy is
+// the 0.4.0 source, byte-for-byte identical to the pod's Classes/.
 let package = Package(
     name: "safe_device",
     platforms: [
@@ -10,16 +16,21 @@ let package = Package(
         .iOS("12.0")
     ],
     products: [
-        .library(name: "safe-device", targets: ["safe_device"])
+        .library(name: "safe-device", targets: ["safe_device"]),
+        // Expose DTT as a product too, so consumers that reference it explicitly still link.
+        .library(name: "DTTJailbreakDetection", targets: ["DTTJailbreakDetection"])
     ],
-    dependencies: [
-        .package(url: "https://github.com/thii/DTTJailbreakDetection.git", from: "0.4.0")
-    ],
+    dependencies: [],
     targets: [
+        .target(
+            name: "DTTJailbreakDetection",
+            path: "Sources/DTTJailbreakDetection",
+            publicHeadersPath: "include/DTTJailbreakDetection"
+        ),
         .target(
             name: "safe_device",
             dependencies: [
-                .product(name: "DTTJailbreakDetection", package: "DTTJailbreakDetection")
+                "DTTJailbreakDetection"
             ],
             // Implementation (.m) files live in Sources/safe_device/, public headers
             // (.h) in Sources/safe_device/include/safe_device/. The header search path

--- a/ios/safe_device/Sources/DTTJailbreakDetection/DTTJailbreakDetection.m
+++ b/ios/safe_device/Sources/DTTJailbreakDetection/DTTJailbreakDetection.m
@@ -1,0 +1,98 @@
+//  DTTJailbreakDetection.m
+//
+//  Copyright (c) 2014 Doan Truong Thi
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import "DTTJailbreakDetection.h"
+
+@implementation DTTJailbreakDetection
+
++ (BOOL)isJailbroken
+{
+#if !(TARGET_IPHONE_SIMULATOR)
+
+    FILE *file = fopen("/Applications/Cydia.app", "r");
+    if (file) {
+        fclose(file);
+        return YES;
+    }
+    file = fopen("/Library/MobileSubstrate/MobileSubstrate.dylib", "r");
+    if (file) {
+        fclose(file);
+        return YES;
+    }
+    file = fopen("/bin/bash", "r");
+    if (file) {
+        fclose(file);
+        return YES;
+    }
+    file = fopen("/usr/sbin/sshd", "r");
+    if (file) {
+        fclose(file);
+        return YES;
+    }
+    file = fopen("/etc/apt", "r");
+    if (file) {
+        fclose(file);
+        return YES;
+    }
+    file = fopen("/usr/bin/ssh", "r");
+    if (file) {
+        fclose(file);
+        return YES;
+    }
+    
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+
+    if ([fileManager fileExistsAtPath:@"/Applications/Cydia.app"]) {
+        return YES;
+    } else if ([fileManager fileExistsAtPath:@"/Library/MobileSubstrate/MobileSubstrate.dylib"]) {
+        return YES;
+    } else if ([fileManager fileExistsAtPath:@"/bin/bash"]) {
+        return YES;
+    } else if ([fileManager fileExistsAtPath:@"/usr/sbin/sshd"]) {
+        return YES;
+    } else if ([fileManager fileExistsAtPath:@"/etc/apt"]) {
+        return YES;
+    } else if ([fileManager fileExistsAtPath:@"/usr/bin/ssh"]) {
+        return YES;
+    }
+    
+    // Check if the app can access outside of its sandbox
+    NSError *error = nil;
+    NSString *string = @".";
+    [string writeToFile:@"/private/jailbreak.txt" atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    if (!error) {
+        return YES;
+    } else {
+        [fileManager removeItemAtPath:@"/private/jailbreak.txt" error:nil];
+    }
+    
+    // Check if the app can open a Cydia's URL scheme
+    if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"cydia://package/com.example.package"]]) {
+        return YES;
+    }
+
+#endif
+
+    return NO;
+}
+
+@end

--- a/ios/safe_device/Sources/DTTJailbreakDetection/DTTJailbreakDetection.m
+++ b/ios/safe_device/Sources/DTTJailbreakDetection/DTTJailbreakDetection.m
@@ -21,6 +21,7 @@
 //
 
 #import "DTTJailbreakDetection.h"
+#import <UIKit/UIKit.h>
 
 @implementation DTTJailbreakDetection
 

--- a/ios/safe_device/Sources/DTTJailbreakDetection/include/DTTJailbreakDetection/DTTJailbreakDetection.h
+++ b/ios/safe_device/Sources/DTTJailbreakDetection/include/DTTJailbreakDetection/DTTJailbreakDetection.h
@@ -1,0 +1,29 @@
+//  DTTJailbreakDetection.h
+//
+//  Copyright (c) 2014 Doan Truong Thi
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to
+//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//  the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface DTTJailbreakDetection : NSObject
+
++ (BOOL)isJailbroken;
+
+@end


### PR DESCRIPTION
## Problem

After the SwiftPM support added in #105 (shipped in 1.4.0), iOS builds with SPM enabled fail to resolve package dependencies:

```
xcodebuild: error: Could not resolve package dependencies:
  the package manifest at '/Package.swift' cannot be accessed (/Package.swift doesn't exist in file system)
```

Fixes #106.

## Root cause

`ios/safe_device/Package.swift` declares a remote dependency:

```swift
.package(url: "https://github.com/thii/DTTJailbreakDetection.git", from: "0.4.0")
```

But [`thii/DTTJailbreakDetection`](https://github.com/thii/DTTJailbreakDetection) is a **CocoaPods-only** repo — it has no `Package.swift` (verified: `curl …/Package.swift → 404`, and the repo tree contains only `.podspec` + `Classes/`). SwiftPM therefore cannot load its manifest, the path collapses to `/`, and resolution aborts. The misleading `/Package.swift` message hides which package is at fault.

## Fix

Vendor the DTT 0.4.0 source (a single `.h`/`.m` pair, byte-for-byte identical to the pod's `Classes/`) directly into the package:

- `Sources/DTTJailbreakDetection/DTTJailbreakDetection.{h,m}` — vendored source
- Expose `DTTJailbreakDetection` as a **local** target + product
- `safe_device` depends on it **by name** (intra-package), removing the broken remote reference

### Why vendor instead of fork?
- The library is ~80 lines and effectively unmaintained (last release 2015-ish).
- It already ships as a CocoaPods dependency, so bundling the tiny source keeps the SPM graph hermetic (no extra remote to fetch/resolve, no abandoned-fork trust concerns for a security-sensitive jailbreak-detection API).

## Compatibility

No functional change. `#import <DTTJailbreakDetection/DTTJailbreakDetection.h>` still resolves, `[DTTJailbreakDetection isJailbroken]` works unchanged. The `DTTJailbreakDetection` product is still published, so any external consumer referencing it explicitly keeps linking.

## Verification

- `swift package describe` and `dump-package` parse cleanly (two targets: `DTTJailbreakDetection`, `safe_device`; the latter depends on the former by name).
- `swift build --target DTTJailbreakDetection --triple arm64-apple-ios16.0-simulator` compiles.
- In a downstream Flutter app with SPM enabled, `xcodebuild -resolvePackageDependencies` now succeeds (previously failed on every build).